### PR TITLE
30 add a static version of latest data into app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-data/*
-
 # History files
 .Rhistory
 .Rapp.history

--- a/R/mod_search.R
+++ b/R/mod_search.R
@@ -9,9 +9,16 @@
 #' @importFrom shiny NS tagList 
 #' 
 
-search_data <- readRDS('inst/app/data/tmp_data.rds') |>
-  dplyr::select(Citation, `Publication year`, Link) |>
-  dplyr::group_by(Citation, `Publication year`, Link) |> 
+data <- evidence_maps::my_dataset |> 
+  dplyr::mutate(
+    id = dplyr::row_number(),
+    Link = paste0("<a href='", Link, "' target = 'new'>", "Link", "</a>")
+  )
+
+
+search_data <- evidence_maps::my_dataset |> 
+  dplyr::select(Authors, Title, `Publication year`, Link) |>
+  dplyr::group_by(Authors, Title, `Publication year`, Link) |> 
   dplyr::summarise(tmp = dplyr::n()) |> 
   dplyr::select(-tmp) |>
   dplyr::ungroup() |> 
@@ -22,7 +29,7 @@ search_data <- readRDS('inst/app/data/tmp_data.rds') |>
   
   
 data_string_split <- search_data |>
-  dplyr::mutate(search_string = paste(Citation, `Publication year`)) |>
+  dplyr::mutate(search_string = paste(Authors, Title, `Publication year`)) |>
   dplyr::select(id, search_string) |>
   tidyr::separate_longer_delim(search_string, delim = " ") |>
   dplyr::mutate(search_string = stringr::str_remove_all(search_string,"[^A-Za-z]"),

--- a/R/mod_summary_table.R
+++ b/R/mod_summary_table.R
@@ -39,9 +39,7 @@ mod_summary_table_ui <- function(id) {
         "Study design",
         "Effect",
         "Setting",
-        "Demographic",
-        "No variable selected" = "no_value"
-      ),
+        "Demographic"),
       selected = "",
       multiple = T
     ),
@@ -93,7 +91,8 @@ mod_summary_table_server <- function(id) {
         dplyr::select(tidyselect::any_of(c(
           "Mechanism",
           "Type of evidence",
-          "Citation",
+          "Authors",
+          "Title",
           "Publication year",
           "Link",
           input$varSelect

--- a/data-raw/.gitignore
+++ b/data-raw/.gitignore
@@ -1,0 +1,1 @@
+evidence_map_data.xlsx

--- a/data-raw/my_dataset.R
+++ b/data-raw/my_dataset.R
@@ -1,25 +1,154 @@
 ## code to prepare `my_dataset` dataset goes here
 
-tmp_data <- readRDS("inst/app/data/tmp_data.rds")
+# Studies ----
+studies <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
+                             sheet = "Studies") |> 
+  dplyr::rename("Link" = `Link to full text`,
+                "Setting" = `...19`,
+                "Effect" = `Effect\r\n(statistical rather than clinical significance?)`) |> 
+  dplyr::select(`Unique ref no`,
+                `Authors`,
+                `Publication year`,
+                `Title`,
+                `Journal`,
+                `Abstract`,
+                `Country of study`,
+                `Link`,
+                `Type of evidence`,
+                `Mechanism`,
+                `Population`,
+                `Setting`,
+                38:47,
+                 `Effect`) 
 
-evidence_types <- c('primary', 'tertiary', 'grey')
-                                 
+studies_outcome_idxs <- tibble::tibble(start_col = seq(which(colnames(studies) == "Outcomes reported"),
+                                                    which(colnames(studies) == "Outcomes reported") + 9,
+                                                    2),
+                                    end_col = seq(which(colnames(studies) == "Outcomes reported") + 1,
+                                                  which(colnames(studies) == "Outcomes reported") + 9,
+                                                  2)) 
 
-create_sample_data <- function(x){
+fn_nest_studies <- function(start_col, end_col){
   
-  tmp_data |> 
-    dplyr::mutate(`Type of evidence` = x,
-                  `Unique ref no` = stringr::str_replace(`Unique ref no`,
-                                                         '[:alpha:]',
-                                                         substring(x,1,1)),
-                  Mechanism = rep(c('?', 'Avoid', 'Substitute'), 
-                                  length.out = nrow(tmp_data)),
-                  Citation = paste('sample_data', `Unique ref no`, Citation)
-    )
+tmp <- studies |> 
+  dplyr::select(`Unique ref no`, start_col, end_col)
+
+tmp_new <- tmp
+
+tmp_new[2,2] <- paste(tmp[[1,2]], tmp[2,2], sep = ".")
+tmp_new[2,3] <- paste(tmp[[1,2]], tmp[2,3], sep = ".")
+
+names(tmp_new)[2:3] <- tmp_new[2,2:3]
+
+tmp_new <- tmp_new[-(1:2),]
+
+tmp_new |> dplyr::mutate(outcome_recorded = ifelse(!is.na(tmp_new[[2]]), T, F)) |> 
+  tidyr::pivot_longer(-c(`Unique ref no`, outcome_recorded), 
+                        names_to = "outcome_info",
+                        values_to = "outcome_value") |> 
+  dplyr::mutate(outcome = stringr::str_extract(outcome_info,
+                                               ".*(?=\\.)"),
+                outcome_info = stringr::str_extract(outcome_info,
+                                                    "(?<=\\.).*")) |> 
+  dplyr::group_by(`Unique ref no`, outcome, outcome_recorded) |> 
+  tidyr::nest() |> 
+  dplyr::ungroup()
+ 
 }
 
-my_dataset <- purrr::map(evidence_types, create_sample_data) |> 
+nested_studies <- purrr::map2(studies_outcome_idxs$start_col,
+                               studies_outcome_idxs$end_col,
+                               fn_nest_studies) |> 
   purrr::list_rbind() |> 
-  rbind(tmp_data) 
+  dplyr::filter(!is.na(`Unique ref no`))
+
+
+studies_final <- studies |> 
+  dplyr::filter(!is.na(`Unique ref no`) &
+                  !is.na(`Authors`)) |> 
+  dplyr::select(-c(`Outcomes reported`:`...47`)) |> 
+  dplyr::left_join(nested_studies, 
+                   by = "Unique ref no",
+                   relationship = "many-to-many") |> 
+  dplyr::mutate(evidence_category = "study")
+  
+# Reviews ---- 
+
+reviews <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
+                             sheet = "Reviews") |> 
+  dplyr::rename("Link" = `Link to full text`,
+                "Setting" = `...19`,
+                "Effect" = `Effect\r\n(statistical rather than clinical significance?)`) |> 
+  dplyr::select(`Unique ref no`,
+                `Authors`,
+                `Publication year`,
+                `Title`,
+                `Journal`,
+                `Abstract`,
+                `Country of study`,
+                `Link`,
+                `Type of evidence`,
+                `Mechanism`,
+                `Population`,
+                `Setting`,
+                37:46,
+                `Effect`)
+
+reviews_outcome_idxs <- tibble::tibble(start_col = seq(which(colnames(reviews) == "Outcomes reported"),
+                                                       which(colnames(reviews) == "Outcomes reported") + 9,
+                                                       2),
+                                       end_col = seq(which(colnames(reviews) == "Outcomes reported") + 1,
+                                                     which(colnames(reviews) == "Outcomes reported") + 9,
+                                                     2)) 
+
+fn_nest_reviews <- function(start_col, end_col){
+  
+  tmp <- reviews |> 
+    dplyr::select(`Unique ref no`, start_col, end_col)
+  
+  tmp_new <- tmp
+  
+  tmp_new[2,2] <- paste(tmp[[1,2]], tmp[2,2], sep = ".")
+  tmp_new[2,3] <- paste(tmp[[1,2]], tmp[2,3], sep = ".")
+  
+  names(tmp_new)[2:3] <- tmp_new[2,2:3]
+  
+  tmp_new <- tmp_new[-(1:2),]
+  
+  tmp_new |> dplyr::mutate(outcome_recorded = ifelse(!is.na(dplyr::across(2)), T, F)) |> 
+    tidyr::pivot_longer(-c(`Unique ref no`, outcome_recorded), 
+                        names_to = "outcome_info",
+                        values_to = "outcome_value") |> 
+    dplyr::mutate(outcome = stringr::str_extract(outcome_info,
+                                                 ".*(?=\\.)"),
+                  outcome_info = stringr::str_extract(outcome_info,
+                                                      "(?<=\\.).*")) |> 
+    dplyr::group_by(`Unique ref no`, outcome, outcome_recorded) |> 
+    tidyr::nest() |> 
+    dplyr::ungroup()
+  
+}
+
+# bug? for hospital admission outcome, the 
+# outcome_recorded for review R004 is false, but inside the nested df
+# there is data recorded, however the function when run with 
+
+nested_reviews <- purrr::map2(reviews_outcome_idxs$start_col,
+                              reviews_outcome_idxs$end_col,
+                              fn_nest_reviews) |> 
+  purrr::list_rbind() |> 
+  dplyr::filter(!is.na(`Unique ref no`))
+
+reviews_final <- reviews |> 
+  dplyr::filter(!is.na(`Unique ref no`) &
+                  !is.na(`Authors`)) |> 
+  dplyr::select(-c(`Outcomes reported`:`...46`)) |> 
+  dplyr::left_join(nested_studies, 
+                   by = "Unique ref no",
+                   relationship = "many-to-many") |> 
+  dplyr::mutate(evidence_category = "review")
+
+my_dataset <- dplyr::bind_rows(studies_final,
+                        reviews_final) 
 
 usethis::use_data(my_dataset, overwrite = TRUE)

--- a/data-raw/my_dataset.R
+++ b/data-raw/my_dataset.R
@@ -145,6 +145,8 @@ reviews_final <- reviews |>
   dplyr::mutate(evidence_category = "review")
 
 my_dataset <- dplyr::bind_rows(studies_final,
-                        reviews_final) 
+                        reviews_final) |> 
+  dplyr::mutate(`Type of evidence` = stringr::str_to_title(`Type of evidence`))
+  
 
 usethis::use_data(my_dataset, overwrite = TRUE)

--- a/data-raw/my_dataset.R
+++ b/data-raw/my_dataset.R
@@ -129,10 +129,6 @@ fn_nest_reviews <- function(start_col, end_col){
   
 }
 
-# bug? for hospital admission outcome, the 
-# outcome_recorded for review R004 is false, but inside the nested df
-# there is data recorded, however the function when run with 
-
 nested_reviews <- purrr::map2(reviews_outcome_idxs$start_col,
                               reviews_outcome_idxs$end_col,
                               fn_nest_reviews) |> 

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Uses a static version of latest evidence map data
- Requires unique ref id for each evidence
- Takes outcomes and pivots longer, stores outcome details inside nested column, keeps a binary variable if an outcome is recorded or not

Evidence map loads without error, however there is more data cleaning/validation to do.

Also closes #20 
