### PR TITLE
Creates taxonomy tab with examples of both table and text

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -6,7 +6,7 @@
 #' @noRd
 app_server <- function(input, output, session) {
   # Your application server logic
-  
+  mod_taxonomy_server("taxonomy_1")
   mod_summary_table_server("summary_table")
   mod_search_server("search")
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -15,26 +15,22 @@ app_ui <- function(request) {
     bs4Dash::sidebarMenu(
       id = "sidebarMenu",
       bs4Dash::menuItem(
-        "Taxonomy",
-        tabName = "tab_taxonomy"),
-      
-      bs4Dash::menuItem(
         "Summary Table",
         tabName = "tab_summary"),
       
       bs4Dash::menuItem(
         "Evidence Search",
         tabName = "tab_search"
+      ),
+      
+      bs4Dash::menuItem(
+        "Taxonomy",
+        tabName = "tab_taxonomy")
       )
-  )
-  )
+    )
   
   body <- bs4Dash::dashboardBody(
     bs4Dash::tabItems(
-      bs4Dash::tabItem(
-        tabName = "tab_taxonomy",
-        mod_taxonomy_ui("taxonomy_1")
-        ),
       bs4Dash::tabItem(
         tabName = "tab_summary",
         mod_summary_table_ui("summary_table")
@@ -42,7 +38,11 @@ app_ui <- function(request) {
       bs4Dash::tabItem(
         tabName = "tab_search",
         mod_search_ui("search")
-      )
+        ),
+      bs4Dash::tabItem(
+        tabName = "tab_taxonomy",
+        mod_taxonomy_ui("taxonomy_1")
+        )
     )
   )
   

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -15,6 +15,10 @@ app_ui <- function(request) {
     bs4Dash::sidebarMenu(
       id = "sidebarMenu",
       bs4Dash::menuItem(
+        "Taxonomy",
+        tabName = "tab_taxonomy"),
+      
+      bs4Dash::menuItem(
         "Summary Table",
         tabName = "tab_summary"),
       
@@ -27,6 +31,10 @@ app_ui <- function(request) {
   
   body <- bs4Dash::dashboardBody(
     bs4Dash::tabItems(
+      bs4Dash::tabItem(
+        tabName = "tab_taxonomy",
+        mod_taxonomy_ui("taxonomy_1")
+        ),
       bs4Dash::tabItem(
         tabName = "tab_summary",
         mod_summary_table_ui("summary_table")

--- a/R/mod_taxonomy.R
+++ b/R/mod_taxonomy.R
@@ -1,0 +1,67 @@
+#' taxonomy UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd 
+#'
+#' @importFrom shiny NS tagList 
+#' 
+
+taxonomy_raw <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
+                              sheet = "Taxonomy")
+
+mechanisms <- taxonomy_raw[2:8,] |> 
+  janitor::row_to_names(1) |> 
+  dplyr::rename("Notes?" = 5) |> 
+  gt::gt(rowname_col = "Mechanism") |> 
+  gt::tab_stubhead(label = "Mechanism") |> 
+  gt::tab_options(table.font.size = "12px",
+                  column_labels.font.size = "14px",
+                  column_labels.font.weight = "bold",
+                  stub.font.size = "14px")
+
+conditions <- taxonomy_raw[11:28,1] |> 
+  janitor::row_to_names(1)
+
+mod_taxonomy_ui <- function(id){
+  ns <- NS(id)
+  tagList(
+    h3("Mechanisms"),
+    gt::gt_output(ns("mechanisms_gt")),
+    h3("Conditions"),
+    shiny::htmlOutput(ns("conditions_txt"))
+ 
+  )
+}
+    
+#' taxonomy Server Functions
+#'
+#' @noRd 
+mod_taxonomy_server <- function(id){
+  moduleServer( id, function(input, output, session){
+    ns <- session$ns
+ 
+    output$mechanisms_gt <- gt::render_gt(mechanisms)
+    
+    output$conditions_txt <- shiny::renderUI({
+      HTML(paste(conditions$`Health conditions`,
+                  collapse = 
+                  '<br>
+                  <br>
+                  <font size = "2">
+                  [Placeholder text]
+                  </font>   
+                  <hr>
+                 <br>'))
+      })
+    
+  })
+}
+    
+## To be copied in the UI
+# mod_taxonomy_ui("taxonomy_1")
+    
+## To be copied in the server
+# mod_taxonomy_server("taxonomy_1")


### PR DESCRIPTION
There should now be a Taxonomy tab, that has a table with the Mechanisms documentation and printed texted for the Health Conditions documentation 