### PR TITLE
33 handle waffle production error given low sample size

### DIFF
--- a/R/mod_summary_table.R
+++ b/R/mod_summary_table.R
@@ -205,37 +205,38 @@ mod_summary_table_server <- function(id) {
     # # waffle ----
 
 
-    output$waffle <- shiny::renderPlot({
+    output$waffle <- shiny::renderPlot(res = 120, 
+                                       {
       shiny::req(input$evidenceMap_cells_selected)
       
       group_val <- map_col_cat()
       
       filtered_waffle_data <- summary_tab_data() |>
         dplyr::select(map_row_cat(), map_col_cat()) |>
-        dplyr::filter(.data[[map_row_cat()]] == selectedCell$row) |>
-        ggwaffle::waffle_iron(mapping = paste0(map_col_cat()))|>
-        dplyr::mutate(selected = ifelse(group == selectedCell$col, T, F))
+        dplyr::filter(.data[[map_row_cat()]] == selectedCell$row) 
 
       shiny::req(filtered_waffle_data)
       filtered_waffle_data |>
+        ggwaffle::waffle_iron(mapping = paste0(map_col_cat()),
+                              rows = floor(sqrt(nrow(filtered_waffle_data))))|>
+        dplyr::mutate(selected = ifelse(group == selectedCell$col, T, F)) |> 
         ggplot2::ggplot(ggplot2::aes(x, y, fill = group)) +
         ggwaffle::geom_waffle() +
         ggwaffle::geom_waffle(
-          data = filtered_waffle_data |>
-            dplyr::filter(selected == T),
+          data = ~dplyr::filter(.x, 
+                                selected == T),
           colour = "blue",
-          show.legend = F
-        ) +
+          show.legend = F) +
         ggplot2::coord_equal() +
         viridis::scale_fill_viridis(discrete = T) +
         ggwaffle::theme_waffle() +
         ggplot2::theme(
           axis.title.x = ggplot2::element_blank(),
           axis.title.y = ggplot2::element_blank(),
-          legend.position = "top",
+          legend.position = "bottom",
           legend.title = ggplot2::element_blank()
         ) +
-        ggplot2::guides(fill = ggplot2::guide_legend(nrow = 2, byrow = T))
+        ggplot2::guides(fill = ggplot2::guide_legend(nrow = 1, byrow = T))
     })
 
     # 

--- a/data-raw/.gitignore
+++ b/data-raw/.gitignore
@@ -1,1 +1,2 @@
 evidence_map_data.xlsx
+tmp_data.xlsx

--- a/data-raw/my_dataset.R
+++ b/data-raw/my_dataset.R
@@ -1,7 +1,7 @@
 ## code to prepare `my_dataset` dataset goes here
 
 # Studies ----
-studies <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
+studies <- readxl::read_xlsx("data-raw/tmp_data.xlsx",
                              sheet = "Studies") |> 
   dplyr::rename("Link" = `Link to full text`,
                 "Setting" = `...19`,
@@ -74,7 +74,7 @@ studies_final <- studies |>
   
 # Reviews ---- 
 
-reviews <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
+reviews <- readxl::read_xlsx("data-raw/tmp_data.xlsx",
                              sheet = "Reviews") |> 
   dplyr::rename("Link" = `Link to full text`,
                 "Setting" = `...19`,


### PR DESCRIPTION
Changes:

- Latest dataset is added (this version of the data has a number of variations for the Primary and Secondary columns/spellings)

- Uses sqrt to avoid the sample error issue, now if a single value exists in a selected row the waffle should produce, even if it only shows one 'square'.

Also potentially closes #22 