### PR TITLE
Remove toggle switches

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -26,23 +26,23 @@ app_ui <- function(request) {
       bs4Dash::menuItem(
         "Taxonomy",
         tabName = "tab_taxonomy")
-      )
     )
+  )
   
   body <- bs4Dash::dashboardBody(
     bs4Dash::tabItems(
       bs4Dash::tabItem(
         tabName = "tab_summary",
         mod_summary_table_ui("summary_table")
-        ),
+      ),
       bs4Dash::tabItem(
         tabName = "tab_search",
         mod_search_ui("search")
-        ),
+      ),
       bs4Dash::tabItem(
         tabName = "tab_taxonomy",
         mod_taxonomy_ui("taxonomy_1")
-        )
+      )
     )
   )
   
@@ -53,11 +53,13 @@ app_ui <- function(request) {
     # Your application UI logic
     shinyjs::useShinyjs(),
     bs4Dash::dashboardPage(
+      help = NULL,
+      dark = NULL,
       header,
       sidebar,
       body
     ) 
-    )
+  )
   
 }
 
@@ -75,7 +77,7 @@ golem_add_external_resources <- function() {
     "www",
     app_sys("app/www")
   )
-
+  
   tags$head(
     favicon(),
     bundle_resources(

--- a/R/mod_summary_table.R
+++ b/R/mod_summary_table.R
@@ -194,10 +194,11 @@ mod_summary_table_server <- function(id, my_dataset) {
         dplyr::left_join(
           summary_tab_data() |>
             dplyr::count(.data[[map_row_cat()]], 
-                         .data[[map_col_cat()]])
+                         .data[[map_col_cat()]]),
             # dplyr::select(map_row_cat(), map_col_cat()) |>
             # dplyr::group_by(map_row_cat(), map_col_cat()) |>
             # dplyr::summarise(count = dplyr::n())
+          by = dplyr::join_by(Mechanism, typeOfEvidence)
         ) |>
         tidyr::pivot_wider(
           names_from = map_col_cat(),


### PR DESCRIPTION
Closes #63.

* Removes unneeded darkmode and help toggle switches in upper-right of UI.
* Quietens console message `` Joining with `by = join_by(Mechanism, typeOfEvidence)` `` by specifying in the code directly.