### PR TITLE
Update holder in license files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2023
-COPYRIGHT HOLDER: Crown Copyright
+YEAR: 2024
+COPYRIGHT HOLDER: The Strategy Unit

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 Crown Copyright
+Copyright (c) 2024 The Strategy Unit
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Closes #61.

* Changes 'Crown Copyright' to 'The Strategy Unit' in license files.