### PR TITLE
Refactor and simplify taxonomy code, avoid extra pin read

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -6,10 +6,12 @@
 #' @noRd
 app_server <- function(input, output, session) {
   
-  evidence_data <- get_data()
+  evidence_list <- get_pinned_data()
+  evidence_data <- get_evidence_data(evidence_list)
+  taxonomy_raw_data <- evidence_list[["About this map"]]
   
-  mod_taxonomy_server("taxonomy_1")
   mod_summary_table_server("summary_table", evidence_data)
   mod_search_server("search", evidence_data)
+  mod_taxonomy_server("taxonomy_1", taxonomy_raw_data)
   
 }

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -14,18 +14,9 @@ app_ui <- function(request) {
     status = "primary",
     bs4Dash::sidebarMenu(
       id = "sidebarMenu",
-      bs4Dash::menuItem(
-        "Summary Table",
-        tabName = "tab_summary"),
-      
-      bs4Dash::menuItem(
-        "Evidence Search",
-        tabName = "tab_search"
-      ),
-      
-      bs4Dash::menuItem(
-        "Taxonomy",
-        tabName = "tab_taxonomy")
+      bs4Dash::menuItem("Summary Table", tabName = "tab_summary"),
+      bs4Dash::menuItem("Evidence Search", tabName = "tab_search"),
+      bs4Dash::menuItem("Taxonomy", tabName = "tab_taxonomy")
     )
   )
   
@@ -46,7 +37,6 @@ app_ui <- function(request) {
     )
   )
   
-  
   shiny::tagList(
     # Leave this function for adding external resources
     golem_add_external_resources(),
@@ -62,7 +52,6 @@ app_ui <- function(request) {
   )
   
 }
-
 
 #' Add external Resources to the Application
 #'

--- a/R/fct_data.R
+++ b/R/fct_data.R
@@ -6,9 +6,19 @@
 #'
 #' @noRd
 
-get_data <- function(pin_name = "matt.dray/nhp_evidence_map_data") {
+# Fetch pin (a list where each element is a sheet from the workbook)
+get_pinned_data <- function(pin_name = "matt.dray/nhp_evidence_map_data") {
   
-  pinned_data <- get_pinned_data(pin_name)
+  board <- pins::board_connect()
+  pin_exists <- pins::pin_exists(board, pin_name)
+  
+  if (!pin_exists) stop(glue::glue("The pin {pin_name} could not be found"))
+  if (pin_exists) pins::pin_read(board, pin_name)
+  
+}
+
+# Extract and wrangle studies and reports data from pin
+get_evidence_data <- function(pinned_data = get_pinned_data()) {
   
   wrangled_studies <- wrangle_studies(pinned_data)
   wrangled_reviews <- wrangle_reviews(pinned_data)
@@ -21,14 +31,10 @@ get_data <- function(pin_name = "matt.dray/nhp_evidence_map_data") {
     ) |> 
     dplyr::mutate(
       id = dplyr::row_number(),
-      Link = paste0("<a href='", Link, "' target = 'new'>", "Link", "</a>")) |> 
+      Link = paste0("<a href='", Link, "' target = 'new'>", "Link", "</a>")
+    ) |> 
     dplyr::rename(typeOfEvidence = `Type of evidence`)
   
-}
-
-get_pinned_data <- function(pin_name = "matt.dray/nhp_evidence_map_data") {
-  board <- pins::board_connect()
-  pins::pin_read(board, pin_name)
 }
 
 wrangle_studies <- function(pinned_data) {

--- a/R/fct_taxonomy.R
+++ b/R/fct_taxonomy.R
@@ -1,0 +1,31 @@
+#' taxonomy 
+#'
+#' @description A fct function
+#'
+#' @return The return value, if any, from executing the function.
+#'
+#' @noRd
+
+extract_taxonomy_table <- function(taxonomy_raw_data, rows_i, cols_i, ...) {
+  
+  taxonomy_raw_data |> 
+    dplyr::slice(rows_i) |> 
+    dplyr::select(cols_i) |> 
+    janitor::row_to_names(1) |>
+    dplyr::rename(...) 
+  
+}
+
+create_taxonomy_gt <- function(taxonomy_table) {
+  
+  taxonomy_table |> 
+    gt::gt(rowname_col = names(taxonomy_table[1])) |> 
+    gt::tab_stubhead(label = names(taxonomy_table[1])) |> 
+    gt::tab_options(
+      table.font.size = "12px",
+      column_labels.font.size = "14px",
+      column_labels.font.weight = "bold",
+      stub.font.size = "14px"
+    )
+  
+}

--- a/R/mod_taxonomy.R
+++ b/R/mod_taxonomy.R
@@ -8,101 +8,74 @@
 #'
 #' @importFrom shiny NS tagList 
 #' 
-
-pin_list <- get_pinned_data()
-
-# taxonomy_raw <- readxl::read_xlsx("data-raw/evidence_map_data.xlsx",
-#                                   sheet = "Taxonomy")
-
-taxonomy_raw <- pin_list[["About this map"]]
-
-fun_make_gt <- function(x){
-  x |> 
-    gt::gt(rowname_col = names(x[1])) |> 
-    gt::tab_stubhead(label = names(x[1])) |> 
-    gt::tab_options(table.font.size = "12px",
-                    column_labels.font.size = "14px",
-                    column_labels.font.weight = "bold",
-                    stub.font.size = "14px")
-}
-
-mechanisms <- taxonomy_raw[9:15,] |> 
-  janitor::row_to_names(1) |> 
-  dplyr::rename("Notes" = 5) |> 
-  fun_make_gt()
-
-setting <- taxonomy_raw[17:26, 1:2] |> 
-  janitor::row_to_names(1) |> 
-  dplyr::rename("Description" = 2) |> 
-  fun_make_gt()
-
-
-evidence_type <- taxonomy_raw[28:30, 1:2] |> 
-  janitor::row_to_names(1) |> 
-  dplyr::rename("Description" = 2) |> 
-  fun_make_gt()
-
-
-outcomes <- taxonomy_raw[32:37, 1:2]  |> 
-  janitor::row_to_names(1) |> 
-  dplyr::rename("Description" = 2) |> 
-  fun_make_gt()
-
-effect <- taxonomy_raw[39:43, 1:2] |> 
-  janitor::row_to_names(1) |> 
-  fun_make_gt()
-
 mod_taxonomy_ui <- function(id){
   ns <- NS(id)
   tagList(
-    #h3("Mechanisms"),
-    gt::gt_output(ns("mechanisms_gt")),
-    gt::gt_output(ns("setting_gt")),
-    gt::gt_output(ns("evidence_type_gt")),
-    gt::gt_output(ns("outcomes_gt")),
-    gt::gt_output(ns("effect_gt")),
-    
-    #h3("Setting"),
-    #h3("Evidence Type")
-    #shiny::htmlOutput(ns("conditions_txt"))
- 
+    bs4Dash::box(
+      title = "Mechanisms",
+      width = 12,
+      gt::gt_output(ns("mechanisms_gt"))
+    ),
+    bs4Dash::box(
+      title = "Setting",
+      width = 12,
+      gt::gt_output(ns("setting_gt"))
+    ),
+    bs4Dash::box(
+      title = "Evidence type",
+      width = 12,
+      gt::gt_output(ns("evidence_type_gt"))
+    ),
+    bs4Dash::box(
+      title = "Outcomes",
+      width = 12,
+      gt::gt_output(ns("outcomes_gt"))
+    ),
+    bs4Dash::box(
+      title = "Effect",
+      width = 12,
+      gt::gt_output(ns("effect_gt"))
+    )
   )
 }
-    
+
 #' taxonomy Server Functions
 #'
 #' @noRd 
-mod_taxonomy_server <- function(id){
+mod_taxonomy_server <- function(id, taxonomy_raw_data){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
- 
-    output$mechanisms_gt <- gt::render_gt(mechanisms)
     
-    output$setting_gt <- gt::render_gt(setting)
+    output$mechanisms_gt <- taxonomy_raw_data |> 
+      extract_taxonomy_table(9:15, 1:5, "Notes" = 5) |> 
+      create_taxonomy_gt() |> 
+      gt::render_gt(align = "left")
     
-    output$evidence_type_gt <- gt::render_gt(evidence_type)
+    output$setting_gt <- taxonomy_raw_data |> 
+      extract_taxonomy_table(17:26, 1:2, "Description" = 2) |> 
+      create_taxonomy_gt() |> 
+      gt::render_gt(align = "left")
     
-    output$outcomes_gt <- gt::render_gt(outcomes)
+    output$evidence_type_gt <- taxonomy_raw_data |> 
+      extract_taxonomy_table(28:30, 1:2, "Description" = 2) |> 
+      create_taxonomy_gt() |> 
+      gt::render_gt(align = "left")
     
-    output$effect_gt <- gt::render_gt(effect)
+    output$outcomes_gt <- taxonomy_raw_data |> 
+      extract_taxonomy_table(32:37, 1:2, "Description" = 2) |> 
+      create_taxonomy_gt() |> 
+      gt::render_gt(align = "left")
     
-    # output$conditions_txt <- shiny::renderUI({
-    #   HTML(paste(conditions$`Health conditions`,
-    #               collapse = 
-    #               '<br>
-    #               <br>
-    #               <font size = "2">
-    #               [Placeholder text]
-    #               </font>   
-    #               <hr>
-    #              <br>'))
-    #   })
+    output$effect_gt <- taxonomy_raw_data |> 
+      extract_taxonomy_table(39:43, 1:2, "Description" = 2) |> 
+      create_taxonomy_gt() |> 
+      gt::render_gt(align = "left")
     
   })
 }
-    
+
 ## To be copied in the UI
 # mod_taxonomy_ui("taxonomy_1")
-    
+
 ## To be copied in the server
 # mod_taxonomy_server("taxonomy_1")


### PR DESCRIPTION
Closes #76.

I was going to add the cover page, but it's sensible to refactor the taxonomy first, given the way that data will need to be handled to get data from the pin to the cover in #59.

* `app_server.R` now reads from the pin once and passes data into each tab's server.
* `fct_data.R` adjusted to check if pin exists and make the `get_evidence_data()` function name more meaningful.
* `fct_taxonomy.R` created to house functions that wrangle tables out of the pin's taxonomy data and prepare it as a {gt} object.
* Some small style tweaks.