### PR TITLE
Add deploy/pin-update notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# evidence_maps
+# nhp_evidence_maps
+
+Visit the app: https://connect.strategyunitwm.nhs.uk/nhp_evidence_map/
+
+## About
 
 Evidence maps are a way of visually displaying the body of literature in a specific field in order to show gaps in evidence or study characteristics. 
 
@@ -6,10 +10,53 @@ This shiny application will allow for the interactive exploration of the literat
 
 The application currently uses a dataset containing information about each evidence, such as author, publication date, and study characteristics. This information is then used to create an evidence map of all of the evidence as well as a free text search in order to search the evidence in the dataset by their title or author.
 
-
 Future plans for this application are:
 
 - To extract keywords from literature within the dataset
 - To allow the user to pull additional literature into the application
 - To allow the user to download literature within the dataset
-- To have an application that can be repurposed to work with evidence from a range of different fields. 
+- To have an application that can be repurposed to work with evidence from a range of different fields.
+
+## Developer notes
+
+<details><summary>Click for detail.</summary>
+
+### Update pinned data
+
+The underlying data for this app can be updated independently of the app. The data is stored as a 'pin' on Posit Connect. The app will read the data from the pin using [{pins}](https://pins.rstudio.com/) when the user reaches the app. You can overwrite the existing pin and it will create a new version; you can see and revert to earlier versions of the pin if needed.
+
+This is some illustrative code to update the pinned data:
+
+``` r
+# Connect to board
+board <- pins::board_connect()
+
+# Check existing pin
+pin_name <- "matt.dray/nhp_evidence_map_data"
+board |> pins::pin_exists(pin_name)
+board |> pins::pin_read(pin_name) |> str(1)
+board |> pins::pin_versions(pin_name)
+
+# Read spreadsheet into list
+
+file <- "spreadsheet.xlsx"
+sheet_names <- readxl::excel_sheets(file)
+
+sheets_list <- purrr::map(
+  sheet_names, 
+  \(x) suppressMessages(readxl::read_xlsx(file, sheet = x))
+) |> 
+  purrr::set_names(sheet_names)
+
+# Write to pin
+pins::pin_write(sheets_list, pin_name)
+board |> pins::pin_versions(pin_name)  # should see new version
+```
+
+### Deploy
+
+Run the `deployApp()` call in `dev/03_deploy.R`. If the `appID` is not picked up from `rsconnect::deployments()`, then you'll have to write it in manually. It can be found in the Settings > Info menu after you log in to Posit Connect and view the app (under 'Content ID').
+
+You can read more about [deploying to Posit Connect](https://docs.posit.co/connect/how-to/publish-shiny-app/) and [deploying a Golem app](https://engineering-shiny.org/deploy.html).
+
+</details>

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ board <- pins::board_connect()
 
 # Check existing pin
 pin_name <- "matt.dray/nhp_evidence_map_data"
-board |> pins::pin_exists(pin_name)
-board |> pins::pin_read(pin_name) |> str(1)
-board |> pins::pin_versions(pin_name)
+board |> pins::pin_exists(pin_name)  # logical
+board |> pins::pin_read(pin_name) |> str(1)  # list structure
+board |> pins::pin_versions(pin_name)  # active and past versions
 
 # Read spreadsheet into list
 
@@ -48,9 +48,17 @@ sheets_list <- purrr::map(
 ) |> 
   purrr::set_names(sheet_names)
 
-# Write to pin
-pins::pin_write(sheets_list, pin_name)
+# Write to pin with custom 'notes' metadata
+board |> pins::pin_write(
+  sheets_list,
+  pin_name,
+  metadata = list(notes = "A reminder of changes/reason for upload."),
+  type = "rds"  # otherwise it may autodetect json
+)
+
+# Confirm upload
 board |> pins::pin_versions(pin_name)  # should see new version
+pins::pin_meta(board, pin_name)[["user"]][["notes"]]  # custom notes metadata
 ```
 
 ### Deploy

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -23,20 +23,20 @@ rhub::check_for_cran()
 ## Local, CRAN or Package Manager ----
 ## This will build a tar.gz that can be installed locally,
 ## sent to CRAN, or to a package manager
-devtools::build()
+# devtools::build()
 
 ## RStudio ----
 ## If you want to deploy on RStudio related platforms
-golem::add_rstudioconnect_file()
-golem::add_shinyappsio_file()
-golem::add_shinyserver_file()
+# golem::add_rstudioconnect_file()
+# golem::add_shinyappsio_file()
+# golem::add_shinyserver_file()
 
 ## Docker ----
 ## If you want to deploy via a generic Dockerfile
-golem::add_dockerfile_with_renv()
+# golem::add_dockerfile_with_renv()
 
 ## If you want to deploy to ShinyProxy
-golem::add_dockerfile_with_renv_shinyproxy()
+# golem::add_dockerfile_with_renv_shinyproxy()
 
 
 # Deploy to Posit Connect or ShinyApps.io


### PR DESCRIPTION
Edit, 7 Sep 2024: adding Rhian as a reviewer because this has been open since 11 June. It's just an update to the README, basically.

Closes #70.

* Adds 'developer' section to README with detail on updating the pinned data and deploying the app.
* Comments out some currently unneeded sections of `dev/03_deploy.R`.

This will help with #79.