### PR TITLE
Add double-deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Evidence maps are a way of visually displaying the body of literature in a speci
 
 This shiny application will allow for the interactive exploration of the literature through tools such as evidence maps and text searching. 
 
-The application currently uses a dataset containing information about each evidence, such as author, publication date, and study characteristics. This information is then used to create an evidence map of all of the evidence as well as a free text search in order to search the evidence in the dataset by their title or author.
+The application currently uses a dataset containing information about each evidence, such as author, publication date, and study characteristics.
+This information is then used to create an evidence map of all of the evidence as well as a free text search in order to search the evidence in the dataset by their title or author.
 
 Future plans for this application are:
 
@@ -63,7 +64,7 @@ pins::pin_meta(board, pin_name)[["user"]][["notes"]]  # custom notes metadata
 
 ### Deploy
 
-Run the `deployApp()` call in `dev/03_deploy.R`. If the `appID` is not picked up from `rsconnect::deployments()`, then you'll have to write it in manually. It can be found in the Settings > Info menu after you log in to Posit Connect and view the app (under 'Content ID').
+Run the `dev/03_deploy.R` script to deploy to Posit Connect.
 
 You can read more about [deploying to Posit Connect](https://docs.posit.co/connect/how-to/publish-shiny-app/) and [deploying a Golem app](https://engineering-shiny.org/deploy.html).
 

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -1,59 +1,20 @@
-# Building a Prod-Ready, Robust Shiny Application.
-#
-# README: each step of the dev files is optional, and you don't have to
-# fill every dev scripts before getting started.
-# 01_start.R should be filled at start.
-# 02_dev.R should be used to keep track of your development during the project.
-# 03_deploy.R should be used once you need to deploy your app.
-#
-#
-######################################
-#### CURRENT FILE: DEPLOY SCRIPT #####
-######################################
+deploy <- function(server_name, app_id) {
+  rsconnect::deployApp(
+    appName = "nhp_evidence_maps",
+    appTitle = "NHP: Models of Care evidence-map app",
+    server = server_name,
+    appFiles = c(
+      "R/",
+      "inst/",
+      "NAMESPACE",
+      "DESCRIPTION",
+      "app.R"
+    ),
+    appId = app_id,
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
 
-# Test your app
-
-## Run checks ----
-## Check the package before sending to prod
-devtools::check()
-rhub::check_for_cran()
-
-# Deploy
-
-## Local, CRAN or Package Manager ----
-## This will build a tar.gz that can be installed locally,
-## sent to CRAN, or to a package manager
-# devtools::build()
-
-## RStudio ----
-## If you want to deploy on RStudio related platforms
-# golem::add_rstudioconnect_file()
-# golem::add_shinyappsio_file()
-# golem::add_shinyserver_file()
-
-## Docker ----
-## If you want to deploy via a generic Dockerfile
-# golem::add_dockerfile_with_renv()
-
-## If you want to deploy to ShinyProxy
-# golem::add_dockerfile_with_renv_shinyproxy()
-
-
-# Deploy to Posit Connect or ShinyApps.io
-# In command line.
-rsconnect::deployApp(
-  appName = "nhp_evidence_maps",
-  appTitle = "nhp_evidence_maps",
-  appFiles = c(
-    # Add any additional files unique to your app here.
-    "R/",
-    "inst/",
-    "data/",
-    "NAMESPACE",
-    "DESCRIPTION",
-    "app.R"
-  ),
-  appId = rsconnect::deployments(".")$appID,
-  lint = FALSE,
-  forceUpdate = TRUE
-)
+deploy("connect.strategyunitwm.nhs.uk", 246)
+deploy("connect.su.mlcsu.org", 118)


### PR DESCRIPTION
Close #89. See the parent for more information: https://github.com/The-Strategy-Unit/data_science_planning/issues/71.

* Updated the `deploy.R` script to deploy to the current and new server.
* Edited the README to simplify the deploy instructions.
* I've already deployed to the new server: https://connect.su.mlcsu.org/nhp_evidence_map/ (this currently errors, but that is okay, see below).

The app on the new server currently errors. That's okay. This is because it's looking for the matt.dray/nhp_evidence_map_data pin on the server called connect.strategyunitwm.nhs.uk, but it can't access it. The new server will eventually get the current server's name, so the app will then be looking in the right place for the pin and it will no longer error.

I've already successfully deployed to the new server, so you don't have to try and redeploy it: https://connect.su.mlcsu.org/nhp_evidence_map/